### PR TITLE
Python3系に対応するため

### DIFF
--- a/hello.py
+++ b/hello.py
@@ -1,1 +1,1 @@
-print "read or run"
+print("read or run")


### PR DESCRIPTION
括弧が必要なのだー
